### PR TITLE
direct root page to /reminders 

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -7,8 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-//  this.route('reminders');
-  this.route('reminders', { path: '/' });
+  this.route('reminders', { path: '/reminders' });
 });
 
 

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('reminders', { path: '/reminders' });
+  this.route('reminders');
 });
 
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  beforeModel() {
+    this.transitionTo('reminders'); 
+  }
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -10,10 +10,10 @@ moduleForAcceptance('Acceptance | reminders list');
 test('viewing the homepage', function(assert) {
   server.createList('reminders', 5);
 
-  visit('/');
+  visit('/reminders');
 
   andThen(function() {
-    assert.equal(currentURL(), '/');
+    assert.equal(currentURL(), '/reminders');
     assert.equal(Ember.$('.spec-reminder-item').length, 5);
   });
 });

--- a/tests/unit/routes/reminders-test.js
+++ b/tests/unit/routes/reminders-test.js
@@ -6,6 +6,6 @@ moduleFor('route:reminders', 'Unit | Route | reminders', {
 });
 
 test('it exists', function(assert) {
-  let route = this.subject();
-  assert.ok(route);
+  let reminders = this.subject();
+  assert.ok(reminders);
 });


### PR DESCRIPTION
closes #2 

## Purpose
 Rerouting the root page to the '/reminders' page in order to display the list of reminders. 

## Approach

 By changing the path in our 'route.js' file to '/reminders' and adding a transitionTo() method in the 'index.js' route file, we redirect the root page to the correct page to display the list. We also adjusted the first test in order to make it pass by adding '/reminders'. 


### Learning

Using Ember docs. 


### Test coverage 

Adjusted unit and integration tests to pass. 

