### PR TITLE
Revert reminders

### DIFF
--- a/app/components/update-reminder.js
+++ b/app/components/update-reminder.js
@@ -10,7 +10,7 @@ export default Ember.Component.extend({
       });
     }
     revertReminder() {
-      this.get('store').findRecord('reminder', this.model.id).then(reminder => {
+      this.get('store').findRecord('reminder', this.reminder.id).then(reminder => {
         reminder.rollbackAttributes()
       });
     }

--- a/app/components/update-reminder.js
+++ b/app/components/update-reminder.js
@@ -8,7 +8,7 @@ export default Ember.Component.extend({
       this.get('store').findRecord('reminder', this.reminder.id).then(reminder => {
         reminder.save()
       });
-    }
+    },
     revertReminder() {
       this.get('store').findRecord('reminder', this.reminder.id).then(reminder => {
         reminder.rollbackAttributes()

--- a/app/components/update-reminder.js
+++ b/app/components/update-reminder.js
@@ -6,8 +6,15 @@ export default Ember.Component.extend({
   actions: {
     updateReminder() {
       this.get('store').findRecord('reminder', this.reminder.id).then(reminder => {
-        reminder.save();
+        reminder.save()
+      });
+    }
+    revertReminder() {
+      this.get('store').findRecord('reminder', this.model.id).then(reminder => {
+        reminder.rollbackAttributes()
       });
     }
   }
 });
+
+;

--- a/app/components/update-reminder.js
+++ b/app/components/update-reminder.js
@@ -6,15 +6,13 @@ export default Ember.Component.extend({
   actions: {
     updateReminder() {
       this.get('store').findRecord('reminder', this.reminder.id).then(reminder => {
-        reminder.save()
+        reminder.save();
       });
     },
     revertReminder() {
       this.get('store').findRecord('reminder', this.reminder.id).then(reminder => {
-        reminder.rollbackAttributes()
+        reminder.rollbackAttributes();
       });
     }
   }
 });
-
-;

--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Remember</title>
+    <title>remEmber</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,3 +1,19 @@
+html {
+  font-family: Arial;
+  background-color: #D6E6DF;
+}
+
+.header {
+  text-align: center;
+  font-size: 50px;
+}
+
+.header-container {
+  width: 100%;
+  height: 60px;
+  background-color: #BCDCDA;
+}
+
 .active {
   color: magenta;
 }

--- a/app/templates/components/update-reminder.hbs
+++ b/app/templates/components/update-reminder.hbs
@@ -18,7 +18,7 @@
     </button>
   {{/link-to}}
   {{#if reminder.hasDirtyAttributes}}
-    <button class='revert-reminder-btn' {{action 'revertReminder' on='click'}}>
+    <button class='revert-reminder-btn' {{action 'revertReminder'}}>
       Revert
     </button>
   {{/if}}

--- a/app/templates/components/update-reminder.hbs
+++ b/app/templates/components/update-reminder.hbs
@@ -1,17 +1,26 @@
-<form class="update-reminder-form" {{action 'updateReminder' on="submit"}}>
+<form class='update-reminder-form'>
   <label>
     Title:
-    {{input class="input-title" value=reminder.title}}
+    {{input class='input-title' value=reminder.title}}
   </label>
   <label>
     Date
-    {{input class="input-date" value=reminder.date}}
+    {{input class='input-date' value=reminder.date}}
   </label>
   <label>
     Notes
-    {{textarea class="textarea-notes" value=reminder.notes}}
+    {{textarea class='textarea-notes' value=reminder.notes}}
   </label>
   {{#link-to 'reminders.reminder' reminder.id}}
-    <button class="update-reminder-submit">Submit</button>
+    <button class='update-reminder-submit'
+      {{action 'updateReminder'}}>
+      Submit
+    </button>
   {{/link-to}}
+  {{#if model.hasDirtyAttributes}}
+    <button class='revert-reminder-btn'
+      {{action 'revertReminder' model on='click'}}>
+      Revert
+    </button>
+  {{/if}}
 </form>

--- a/app/templates/components/update-reminder.hbs
+++ b/app/templates/components/update-reminder.hbs
@@ -17,9 +17,8 @@
       Submit
     </button>
   {{/link-to}}
-  {{#if model.hasDirtyAttributes}}
-    <button class='revert-reminder-btn'
-      {{action 'revertReminder' model on='click'}}>
+  {{#if reminder.hasDirtyAttributes}}
+    <button class='revert-reminder-btn' {{action 'revertReminder' on='click'}}>
       Revert
     </button>
   {{/if}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,4 +1,6 @@
-<h1>REMINDERS</h1>
+<div class='header-container'>
+  <h1 class='header'>Reminders:</h1>
+</div>
 {{#if model}}
   {{#each model as |reminder|}}
     {{reminder-item reminder=reminder}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -81,8 +81,8 @@ test('edit reminder and revert to original text by clicking revert button', func
   click('.add-reminder-link-btn');
 
   fillIn('.input-title', 'probably a title');
-  fillIn('input-date', '4/28');
-  fillIn('textarea-notes', 'probably some notes');
+  fillIn('.input-date', '4/28');
+  fillIn('.textarea-notes', 'probably some notes');
 
   click('.add-reminder-submit');
   click('.spec-reminder-title');
@@ -95,11 +95,18 @@ test('edit reminder and revert to original text by clicking revert button', func
   fillIn('.input-title', 'ALLIGATOR');
   fillIn('.input-date', 'TODAY');
   fillIn('.textarea-notes', 'WOWOWOWOWOW');
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder-title').text().trim(), 'ALLIGATOR');
+    assert.equal(Ember.$('.spec-reminder-date').text().trim(), 'TODAY');
+    assert.equal(Ember.$('.spec-reminder-notes').text().trim(), 'WOWOWOWOWOW');
+  });
+
   click('.revert-reminder-btn');
 
   andThen(function() {
     assert.equal(Ember.$('.spec-reminder-title').text().trim(), 'probably a title');
     assert.equal(Ember.$('.spec-reminder-date').text().trim(), '4/28');
     assert.equal(Ember.$('.spec-reminder-notes').text().trim(), 'probably some notes');
-  })
+  });
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -74,3 +74,32 @@ test('when a reminder is deleted on its route, the reminder will be deleted and 
     assert.equal(Ember.$('.spec-reminder-item').length, 4);
   });
 });
+
+test('edit reminder and revert to original text by clicking revert button', function(assert) {
+
+  visit('/');
+  click('.add-reminder-link-btn');
+
+  fillIn('.input-title', 'probably a title');
+  fillIn('input-date', '4/28');
+  fillIn('textarea-notes', 'probably some notes');
+
+  click('.add-reminder-submit');
+  click('.spec-reminder-title');
+  click('.spec-reminder-edit-link');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders/1/edit');
+  });
+
+  fillIn('.input-title', 'ALLIGATOR');
+  fillIn('.input-date', 'TODAY');
+  fillIn('.textarea-notes', 'WOWOWOWOWOW');
+  click('.revert-reminder-btn');
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder-title').text().trim(), 'probably a title');
+    assert.equal(Ember.$('.spec-reminder-date').text().trim(), '4/28');
+    assert.equal(Ember.$('.spec-reminder-notes').text().trim(), 'probably some notes');
+  })
+});


### PR DESCRIPTION
## Purpose

Closes #11 

The user can revert an unsaved reminder to its previous state mid-edit.

## Approach

When actively editing a reminder, if the reminder has unsaved changes, the user will see a button to rollback unsaved changes.
When clicked it will automatically rollback the attributes of the reminder to its original, clean state.

### Learning

EMBER DOCS!!!!

### Test coverage 

We have a test to ensure that the button exists and that clicking it ensures the changes roll back!

### Merge Dependencies and Related Work

_Link to merge dependency issues or PRs._

### Follow-up tasks

- [Issue #12  (Visual Cues on Unsaved Reminders)](https://github.com/turingschool-projects/1610-remember-9/issues/12)
